### PR TITLE
CMS inclusive jets 8 TeV

### DIFF
--- a/CMS_1JET_8TEV/README_appl_CMS_1JET_8TEV
+++ b/CMS_1JET_8TEV/README_appl_CMS_1JET_8TEV
@@ -1,0 +1,7 @@
+*****************************************************************************
+ ExpName: CMS_1JET_8TEV
+ Author: Emanuele R. Nocera (enocera@nikhef.nl)
+ Date: May 2019
+ CodesUsed: applgrids provided by M. Sutton (converted from FastNLO grids)
+ AdditionalInfo: pt_jet as central scale
+*****************************************************************************

--- a/CMS_1JET_8TEV/applgrid-cms-incjets-arxiv-1609.05331-xsec000.root
+++ b/CMS_1JET_8TEV/applgrid-cms-incjets-arxiv-1609.05331-xsec000.root
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b733cb7ee44c5853483eb1bfa4f7737a6dde939f29503d3e0c00a7645e8dda1
+size 34772142

--- a/CMS_1JET_8TEV/applgrid-cms-incjets-arxiv-1609.05331-xsec001.root
+++ b/CMS_1JET_8TEV/applgrid-cms-incjets-arxiv-1609.05331-xsec001.root
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7954810608d47de15a7bbc88a345fd40b23e53792148b96669b4ed2482b1ae14
+size 1394146


### PR DESCRIPTION
This PR includes the NLO applgrids for CMS inclusive jets at 8 TeV.