### PR TITLE
CMS 3D dijets at 8 TeV

### DIFF
--- a/CMS_2JET_3D_8TEV/CMS_2JET_3D_8TEV.tab
+++ b/CMS_2JET_3D_8TEV/CMS_2JET_3D_8TEV.tab
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:591e87742f737107aad8fc5f83530fca504c4084f159dc1a5aeef697940bb973
+size 21213748

--- a/CMS_2JET_3D_8TEV/README_appl_CMS_2JET_3D_8TEV
+++ b/CMS_2JET_3D_8TEV/README_appl_CMS_2JET_3D_8TEV
@@ -1,0 +1,7 @@
+***************************************************************************
+SetName: CMS_2JET_3D_8TEV
+Author:  Emanuele R. Nocera (enocera@nikhef.nl)
+Date:    08.2019
+CodesUsed: NLOjet++
+AdditionalInfo: fastNLO table from hepdata https://www.hepdata.net/record/ins1598460 (needs to be replaced once the in-house computation is finsihed)
+***************************************************************************


### PR DESCRIPTION
This PR contains a **preliminary** fastnlo table for the 3D dijet data form CMS at 8 TeV. This fastNLO table is taken from hepdata
https://www.hepdata.net/record/ins1598460
There is a 1-5% (bin-dependent) discrepancy with Joao Pires nominal results due to the different choice of the central scale. This fastNLO table will be replaced with the correct result computed in-house as soon as enough statistics is produced.