### PR TITLE
Replaced fastNLO grid with correct central scale

### DIFF
--- a/CMS_2JET_3D_8TEV/CMS_2JET_3D_8TEV.tab
+++ b/CMS_2JET_3D_8TEV/CMS_2JET_3D_8TEV.tab
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:591e87742f737107aad8fc5f83530fca504c4084f159dc1a5aeef697940bb973
-size 21213748
+oid sha256:2cea8dd532acc7fadf51851ba315843ae8ab8e57a2a592c5e17fce9fe31837a7
+size 20898510


### PR DESCRIPTION
The replacement is for the 3D dijet distr. from CMS at 8 TeV.