### PR TITLE
Updated applgrids and REDME files

### DIFF
--- a/ATLAS_TTB_DIFF_8TEV_LJ_TRAP/README_appl_ATLAS_TTB_DIFF_8TEV_LJ_TRAP
+++ b/ATLAS_TTB_DIFF_8TEV_LJ_TRAP/README_appl_ATLAS_TTB_DIFF_8TEV_LJ_TRAP
@@ -1,0 +1,7 @@
+***************************************************************************
+SetName: ATLAS_TTB_DIFF_8TEV_LJ_TRAP
+Author:  Nathan P. Hartland (nathan.hartland@physics.ox.ac.uk)
+Date:    02.2016
+CodesUsed: Sherpa/MCgrid
+AdditionalInfo: none
+***************************************************************************

--- a/ATLAS_TTB_DIFF_8TEV_LJ_TRAP/TOPDIFF8TEVTRAP.root
+++ b/ATLAS_TTB_DIFF_8TEV_LJ_TRAP/TOPDIFF8TEVTRAP.root
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4088729402c3f9e1427ade6f5937b1292ba29ffc9645f9ed800a12f3c9f195d3
+size 17267369

--- a/ATLAS_TTB_DIFF_8TEV_LJ_TRAPNORM/README_appl_ATLAS_TTB_DIFF_8TEV_LJ_TRAPNORM
+++ b/ATLAS_TTB_DIFF_8TEV_LJ_TRAPNORM/README_appl_ATLAS_TTB_DIFF_8TEV_LJ_TRAPNORM
@@ -1,0 +1,7 @@
+***************************************************************************
+SetName: ATLAS_TTB_DIFF_8TEV_LJ_TRAPNORM
+Author:  Nathan P. Hartland (nathan.hartland@physics.ox.ac.uk)
+Date:    02.2016
+CodesUsed: Sherpa/MCgrid
+AdditionalInfo: none
+***************************************************************************

--- a/ATLAS_TTB_DIFF_8TEV_LJ_TRAPNORM/TOPDIFF8TEVTOT.root
+++ b/ATLAS_TTB_DIFF_8TEV_LJ_TRAPNORM/TOPDIFF8TEVTOT.root
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73a877b0fbdeb5abb225e87d8c7da00816232362a9a14ac0aa66f2bb9d3e5252
+size 1993508

--- a/ATLAS_TTB_DIFF_8TEV_LJ_TRAPNORM/TOPDIFF8TEVTRAP.root
+++ b/ATLAS_TTB_DIFF_8TEV_LJ_TRAPNORM/TOPDIFF8TEVTRAP.root
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4088729402c3f9e1427ade6f5937b1292ba29ffc9645f9ed800a12f3c9f195d3
+size 17267369

--- a/ATLAS_TTB_DIFF_8TEV_LJ_TTRAP/README_appl_ATLAS_TTB_DIFF_8TEV_LJ_TTRAP
+++ b/ATLAS_TTB_DIFF_8TEV_LJ_TTRAP/README_appl_ATLAS_TTB_DIFF_8TEV_LJ_TTRAP
@@ -1,0 +1,7 @@
+***************************************************************************
+SetName: ATLAS_TTB_DIFF_8TEV_LJ_TTRAP
+Author:  Nathan P. Hartland (nathan.hartland@physics.ox.ac.uk)
+Date:    02.2016
+CodesUsed: Sherpa/MCgrid
+AdditionalInfo: none
+***************************************************************************

--- a/ATLAS_TTB_DIFF_8TEV_LJ_TTRAP/TOPDIFF8TEVTTRAP.root
+++ b/ATLAS_TTB_DIFF_8TEV_LJ_TTRAP/TOPDIFF8TEVTTRAP.root
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72aee589c5669888c0b39da4b02bf07333e999eb151fa9178927a56c2ca3c1fa
+size 14792043

--- a/ATLAS_TTB_DIFF_8TEV_LJ_TTRAPNORM/README_appl_ATLAS_TTB_DIFF_8TEV_LJ_TTRAPNORM
+++ b/ATLAS_TTB_DIFF_8TEV_LJ_TTRAPNORM/README_appl_ATLAS_TTB_DIFF_8TEV_LJ_TTRAPNORM
@@ -1,0 +1,7 @@
+***************************************************************************
+SetName: ATLAS_TTB_DIFF_8TEV_LJ_TTRAPNORM
+Author:  Nathan P. Hartland (nathan.hartland@physics.ox.ac.uk)
+Date:    02.2016
+CodesUsed: Sherpa/MCgrid
+AdditionalInfo: none
+***************************************************************************

--- a/ATLAS_TTB_DIFF_8TEV_LJ_TTRAPNORM/TOPDIFF8TEVTOT.root
+++ b/ATLAS_TTB_DIFF_8TEV_LJ_TTRAPNORM/TOPDIFF8TEVTOT.root
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73a877b0fbdeb5abb225e87d8c7da00816232362a9a14ac0aa66f2bb9d3e5252
+size 1993508

--- a/ATLAS_TTB_DIFF_8TEV_LJ_TTRAPNORM/TOPDIFF8TEVTTRAP.root
+++ b/ATLAS_TTB_DIFF_8TEV_LJ_TTRAPNORM/TOPDIFF8TEVTTRAP.root
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72aee589c5669888c0b39da4b02bf07333e999eb151fa9178927a56c2ca3c1fa
+size 14792043


### PR DESCRIPTION
This PR includes all missing applgrids for the updated implementation of top-pair differential distributions from ATLAS at 8 TeV. 