### PR TITLE
ATLAS top pair 13 TeV

### DIFF
--- a/ATLAS_TTBARTOT_13TEV_FULLLUMI/README_appl_ATLAS_TTBARTOT_13TEV_FULLLUMI
+++ b/ATLAS_TTBARTOT_13TEV_FULLLUMI/README_appl_ATLAS_TTBARTOT_13TEV_FULLLUMI
@@ -1,0 +1,7 @@
+***************************************************************************
+SetName: ATLAS_TTBARTOT_13TEV_FULLLUMI
+Author:  Emanuele R. Nocera (enocera@nikhef.nl)
+Date:    06.2020
+CodesUsed: Sherpa/MCgrid
+AdditionalInfo: none
+***************************************************************************

--- a/ATLAS_TTBARTOT_13TEV_FULLLUMI/TOPDIFF13TEVTOT.root
+++ b/ATLAS_TTBARTOT_13TEV_FULLLUMI/TOPDIFF13TEVTOT.root
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9e1334f2e90e3590add4c048d17594f9741d8d1615be70a313d5ed74b0cd6ac
+size 3431317


### PR DESCRIPTION
This PR contains the applgrids for the ATLAS top pair total cross section at 13 TeV for the measurement based on the full LHC Run II luminosity, see https://github.com/NNPDF/buildmaster/pull/152